### PR TITLE
fix(service): fix to regex so it wont affect autogenerated types

### DIFF
--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -26,7 +26,7 @@ def get_sdl(schema, custom_entities):
     string_schema = pattern.sub(" ", string_schema)
 
     for entity_name, entity in custom_entities.items():
-        type_def_re = r"(type %s[^\{]*)" % entity_name
+        type_def_re = r"(type %s [^\{]*)" % entity_name
         repl_str = r"\1 %s " % entity._sdl
         pattern = re.compile(type_def_re)
         string_schema = pattern.sub(repl_str, string_schema)


### PR DESCRIPTION
I just added a space on the regular expression. The old fix was also including autogenerated types. Example, if I define the node "TestNode", graphene generates in the schema a "TestNodeEdge". With the old regular expression, this type would have also been affected by the change.